### PR TITLE
JavaCC: add new CODE_GENERATOR option for the next new design of JavaCC as per version 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target/
+
+# Eclipse generated files
+bin/
+.settings/
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@ under the License.
       <groupId>net.java.dev.javacc</groupId>
       <artifactId>javacc</artifactId>
       <version>5.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -91,7 +92,7 @@ under the License.
       <!--
       NOTE: Only reflectively accessed to avoid dependency on Java 1.5 for compilation.
       -->
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>

--- a/src/it/explicit-parameter-values/pom.xml
+++ b/src/it/explicit-parameter-values/pom.xml
@@ -4,9 +4,12 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.codehaus.mojo.javacc</groupId>
+  <parent>
+      <groupId>org.codehaus.mojo.javacc</groupId>
+      <artifactId>it</artifactId>
+      <version>1.0-SNAPSHOT</version>
+  </parent>
   <artifactId>it-test</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Integration Test</name>
   <url>http://maven.apache.org</url>
   <description>
@@ -19,6 +22,13 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
         <version>@pom.version@</version>
+        <dependencies>
+            <dependency>
+              <groupId>net.java.dev.javacc</groupId>
+              <artifactId>javacc</artifactId>
+              <version>5.0</version>
+            </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>javacc</id>

--- a/src/it/javacc-absent-source-directory/pom.xml
+++ b/src/it/javacc-absent-source-directory/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-basic/pom.xml
+++ b/src/it/javacc-basic/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-custom-parser-files/pom.xml
+++ b/src/it/javacc-custom-parser-files/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-custom-source-files/pom.xml
+++ b/src/it/javacc-custom-source-files/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-equal-input-output-directory/pom.xml
+++ b/src/it/javacc-equal-input-output-directory/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-grammar-in-source-root/pom.xml
+++ b/src/it/javacc-grammar-in-source-root/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-path-with-spaces/pom.xml
+++ b/src/it/javacc-path-with-spaces/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/javacc-reactor-build/pom.xml
+++ b/src/it/javacc-reactor-build/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>reactor-build</artifactId>
   <packaging>pom</packaging>

--- a/src/it/javacc-stale-detection/pom.xml
+++ b/src/it/javacc-stale-detection/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-absent-source-directory/pom.xml
+++ b/src/it/jjdoc-absent-source-directory/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-basic-site/pom.xml
+++ b/src/it/jjdoc-basic-site/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-basic-standalone/pom.xml
+++ b/src/it/jjdoc-basic-standalone/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-default-source-roots/pom.xml
+++ b/src/it/jjdoc-default-source-roots/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-path-with-spaces/pom.xml
+++ b/src/it/jjdoc-path-with-spaces/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjdoc-reactor-build/pom.xml
+++ b/src/it/jjdoc-reactor-build/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>reactor-build</artifactId>
   <packaging>pom</packaging>

--- a/src/it/jjtree-absent-source-directory/pom.xml
+++ b/src/it/jjtree-absent-source-directory/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-basic/pom.xml
+++ b/src/it/jjtree-basic/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-dynamic-node-package/pom.xml
+++ b/src/it/jjtree-dynamic-node-package/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-javacc-basic/pom.xml
+++ b/src/it/jjtree-javacc-basic/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-javacc-custom-source-files/pom.xml
+++ b/src/it/jjtree-javacc-custom-source-files/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-javacc-pipeline/pom.xml
+++ b/src/it/jjtree-javacc-pipeline/pom.xml
@@ -1,6 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>jjtree-javacc-pipeline</artifactId>
   <packaging>jar</packaging>

--- a/src/it/jjtree-path-with-spaces/pom.xml
+++ b/src/it/jjtree-path-with-spaces/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jjtree-reactor-build/pom.xml
+++ b/src/it/jjtree-reactor-build/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>reactor-build</artifactId>
   <packaging>pom</packaging>

--- a/src/it/jjtree-static-node-package/pom.xml
+++ b/src/it/jjtree-static-node-package/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jtb-absent-source-directory/pom.xml
+++ b/src/it/jtb-absent-source-directory/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jtb-basic/pom.xml
+++ b/src/it/jtb-basic/pom.xml
@@ -1,6 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>jtb-basic</artifactId>
   <packaging>jar</packaging>

--- a/src/it/jtb-dynamic-packages/pom.xml
+++ b/src/it/jtb-dynamic-packages/pom.xml
@@ -1,6 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>jtb-basic</artifactId>
   <packaging>jar</packaging>

--- a/src/it/jtb-javacc-basic/pom.xml
+++ b/src/it/jtb-javacc-basic/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jtb-javacc-custom-source-files/pom.xml
+++ b/src/it/jtb-javacc-custom-source-files/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jtb-path-with-spaces/pom.xml
+++ b/src/it/jtb-path-with-spaces/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>it-test</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/jtb-reactor-build/pom.xml
+++ b/src/it/jtb-reactor-build/pom.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+  	<groupId>org.codehaus.mojo.javacc</groupId>
+  	<artifactId>it</artifactId>
+  	<version>1.0-SNAPSHOT</version>
+  </parent>
   <groupId>org.codehaus.mojo.javacc</groupId>
   <artifactId>reactor-build</artifactId>
   <packaging>pom</packaging>

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.javacc</groupId>
+    <artifactId>it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Integration Test</name>
+    <url>http://maven.apache.org</url>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javacc-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.java.dev.javacc</groupId>
+                        <artifactId>javacc</artifactId>
+                        <version>5.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>edu.ucla.cs.compilers</groupId>
+                        <artifactId>jtb</artifactId>
+                        <version>1.3.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+    <packaging>pom</packaging>
+</project>

--- a/src/main/java/org/codehaus/mojo/javacc/AbstractJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/AbstractJavaCCMojo.java
@@ -282,6 +282,27 @@ public abstract class AbstractJavaCCMojo
     private String grammarEncoding;
 
     /**
+     * The target code generator for compiling this grammar.
+     * 
+     * @parameter property="codeGenerator" default-value="Java"
+     * @since 2.7
+     */
+
+    private String codeGenerator;
+
+    /**
+     * Gets the backend code generator.
+     * 
+     * @return The name of the code generator (Java, C++, C#) or <code>Java</code> if the user did not specify this mojo
+     *         parameter.
+     * @since 2.7
+     */
+    protected String getCodeGenerator()
+    {
+        return this.codeGenerator;
+    }
+
+    /**
      * Gets the file encoding of the grammar files.
      * 
      * @return The file encoding of the grammar files or <code>null</code> if the user did not specify this mojo
@@ -516,7 +537,21 @@ public abstract class AbstractJavaCCMojo
     {
         try
         {
-            Collection tempFiles = FileUtils.getFiles( tempDirectory, "*.java", null );
+            Collection tempFiles = null;
+            if (codeGenerator.equalsIgnoreCase("Java"))
+            {
+            	tempFiles = FileUtils.getFiles( tempDirectory, "*.java", null );
+            } else
+            if (codeGenerator.equalsIgnoreCase("C++"))
+            {
+            	tempFiles = FileUtils.getFiles( tempDirectory, "*.cc", null );
+            	tempFiles.addAll(FileUtils.getFiles( tempDirectory, "*.h", null ));
+            } else
+            if (codeGenerator.equalsIgnoreCase("C#"))
+            {
+            	tempFiles = FileUtils.getFiles( tempDirectory, "*.cs", null );
+            }
+
             for ( Iterator it = tempFiles.iterator(); it.hasNext(); )
             {
                 File tempFile = (File) it.next();

--- a/src/main/java/org/codehaus/mojo/javacc/JavaCC.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JavaCC.java
@@ -178,6 +178,12 @@ class JavaCC
     private Boolean supportClassVisibilityPublic;
 
     /**
+     * The option CODE_GENERATOR.
+     */
+    private String codeGenerator;
+
+    /**
+    /**
      * Sets the absolute path to the grammar file to pass into JavaCC for compilation.
      * 
      * @param value The absolute path to the grammar file to pass into JavaCC for compilation.
@@ -468,6 +474,16 @@ class JavaCC
     }
 
     /**
+     * Sets the option CODE_GENERATOR.
+     * 
+     * @param value The option value, may be <code>null</code> to use the value provided in the grammar or the default.
+     */
+    public void setCodeGenerator( String value )
+    {
+        this.codeGenerator = value;
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected int execute()
@@ -622,6 +638,11 @@ class JavaCC
         if ( this.supportClassVisibilityPublic != null )
         {
             argsList.add( "-SUPPORT_CLASS_VISIBILITY_PUBLIC=" + this.supportClassVisibilityPublic );
+        }
+
+        if ( StringUtils.isNotEmpty( this.codeGenerator ) )
+        {
+            argsList.add( "-CODE_GENERATOR=" + this.codeGenerator );
         }
 
         if ( this.outputDirectory != null )

--- a/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
@@ -26,7 +26,7 @@ import org.apache.maven.plugin.MojoFailureException;
 
 /**
  * Parses a JavaCC grammar file (<code>*.jj</code>) and transforms it to Java source files. Detailed information
- * about the JavaCC options can be found on the <a href="https://javacc.dev.java.net/">JavaCC website</a>.
+ * about the JavaCC options can be found on the <a href="https://github.com/javacc/javacc/">JavaCC website</a>.
  * 
  * @goal javacc
  * @phase generate-sources


### PR DESCRIPTION
Hi

JavaCC 8.0 is the new major version of JavaCC that brings the separation between the parser and various customizable code generator for Java, C++ and C#. Thus, the java-maven-plugin should supports this essential new option.