### PR TITLE
Do not overwrite javacc defaults

### DIFF
--- a/src/main/java/org/codehaus/mojo/javacc/AbstractJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/AbstractJavaCCMojo.java
@@ -65,7 +65,7 @@ public abstract class AbstractJavaCCMojo
      *
      * @since 2.4
      */
-    @Parameter(property = "javacc.jdkVersion", defaultValue = "1.5")
+    @Parameter(property = "javacc.jdkVersion")
     private String jdkVersion;
 
     /**
@@ -73,24 +73,24 @@ public abstract class AbstractJavaCCMojo
      * is <code>1</code>.
      *
      */
-    @Parameter(property = "javacc.lookAhead", defaultValue = "1")
-    private int lookAhead;
+    @Parameter(property = "javacc.lookAhead")
+    private Integer lookAhead;
 
     /**
      * This is the number of tokens considered in checking choices of the form "A | B | ..." for ambiguity. Default
      * value is <code>2</code>.
      *
      */
-    @Parameter(property = "javacc.choiceAmbiguityCheck", defaultValue = "2")
-    private int choiceAmbiguityCheck;
+    @Parameter(property = "javacc.choiceAmbiguityCheck")
+    private Integer choiceAmbiguityCheck;
 
     /**
      * This is the number of tokens considered in checking all other kinds of choices (i.e., of the forms "(A)*",
      * "(A)+", and "(A)?") for ambiguity. Default value is <code>1</code>.
      *
      */
-    @Parameter(property = "javacc.otherAmbiguityCheck", defaultValue = "1")
-    private int otherAmbiguityCheck;
+    @Parameter(property = "javacc.otherAmbiguityCheck")
+    private Integer otherAmbiguityCheck;
 
     /**
      * If <code>true</code>, all methods and class variables are specified as static in the generated parser and
@@ -98,16 +98,16 @@ public abstract class AbstractJavaCCMojo
      * Default value is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.isStatic", defaultValue = "true")
-    private boolean isStatic;
+    @Parameter(property = "javacc.isStatic")
+    private Boolean isStatic;
 
     /**
      * This option is used to obtain debugging information from the generated parser. Setting this option to
      * <code>true</code> causes the parser to generate a trace of its actions. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.debugParser", defaultValue = "false")
-    private boolean debugParser;
+    @Parameter(property = "javacc.debugParser")
+    private Boolean debugParser;
 
     /**
      * This is a boolean option whose default value is <code>false</code>. Setting this option to <code>true</code>
@@ -116,24 +116,24 @@ public abstract class AbstractJavaCCMojo
      * operation.
      *
      */
-    @Parameter(property = "javacc.debugLookAhead", defaultValue = "false")
-    private boolean debugLookAhead;
+    @Parameter(property = "javacc.debugLookAhead")
+    private Boolean debugLookAhead;
 
     /**
      * This option is used to obtain debugging information from the generated token manager. Default value is
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.debugTokenManager", defaultValue = "false")
-    private boolean debugTokenManager;
+    @Parameter(property = "javacc.debugTokenManager")
+    private Boolean debugTokenManager;
 
     /**
      * Setting it to <code>false</code> causes errors due to parse errors to be reported in somewhat less detail.
      * Default value is <code>true</code>.
      * 
      */
-    @Parameter(property = "javacc.errorReporting", defaultValue = "true")
-    private boolean errorReporting;
+    @Parameter(property = "javacc.errorReporting")
+    private Boolean errorReporting;
 
     /**
      * When set to <code>true</code>, the generated parser uses an input stream object that processes Java Unicode
@@ -142,24 +142,24 @@ public abstract class AbstractJavaCCMojo
      * 
      * @parameter property="javaUnicodeEscape"
      */
-    @Parameter(property = "javacc.javaUnicodeEscape", defaultValue = "false")
-    private boolean javaUnicodeEscape;
+    @Parameter(property = "javacc.javaUnicodeEscape")
+    private Boolean javaUnicodeEscape;
 
     /**
      * When set to <code>true</code>, the generated parser uses uses an input stream object that reads Unicode files.
      * By default, ASCII files are assumed. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.unicodeInput", defaultValue = "false")
-    private boolean unicodeInput;
+    @Parameter(property = "javacc.unicodeInput")
+    private Boolean unicodeInput;
 
     /**
      * Setting this option to <code>true</code> causes the generated token manager to ignore case in the token
      * specifications and the input files. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.ignoreCase", defaultValue = "false")
-    private boolean ignoreCase;
+    @Parameter(property = "javacc.ignoreCase")
+    private Boolean ignoreCase;
 
     /**
      * When set to <code>true</code>, every call to the token manager's method <code>getNextToken()</code> (see the
@@ -168,8 +168,8 @@ public abstract class AbstractJavaCCMojo
      * by the token manager. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.commonTokenAction", defaultValue = "false")
-    private boolean commonTokenAction;
+    @Parameter(property = "javacc.commonTokenAction")
+    private Boolean commonTokenAction;
 
     /**
      * The default action is to generate a token manager that works on the specified grammar tokens. If this option is
@@ -178,8 +178,8 @@ public abstract class AbstractJavaCCMojo
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.userTokenManager", defaultValue = "false")
-    private boolean userTokenManager;
+    @Parameter(property = "javacc.userTokenManager")
+    private Boolean userTokenManager;
 
     /**
      * This flag controls whether the token manager will read characters from a character stream reader as defined by
@@ -187,16 +187,16 @@ public abstract class AbstractJavaCCMojo
      * from a user-supplied implementation of <code>CharStream</code>. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.userCharStream", defaultValue = "false")
-    private boolean userCharStream;
+    @Parameter(property = "javacc.userCharStream")
+    private Boolean userCharStream;
 
     /**
      * A flag that controls whether the parser file (<code>*Parser.java</code>) should be generated or not. If set
      * to <code>false</code>, only the token manager is generated. Default value is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.buildParser", defaultValue = "true")
-    private boolean buildParser;
+    @Parameter(property = "javacc.buildParser")
+    private Boolean buildParser;
 
     /**
      * A flag that controls whether the token manager file (<code>*TokenManager.java</code>) should be generated or
@@ -204,8 +204,8 @@ public abstract class AbstractJavaCCMojo
      * grammar changed. Default value is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.buildTokenManager", defaultValue = "true")
-    private boolean buildTokenManager;
+    @Parameter(property = "javacc.buildTokenManager")
+    private Boolean buildTokenManager;
 
     /**
      * When set to <code>true</code>, the generated token manager will include a field called <code>parser</code>
@@ -213,8 +213,8 @@ public abstract class AbstractJavaCCMojo
      * 
      * @parameter property="tokenManagerUsesParser"
      */
-    @Parameter(property = "javacc.tokenManagerUsesParser", defaultValue = "false")
-    private boolean tokenManagerUsesParser;
+    @Parameter(property = "javacc.tokenManagerUsesParser")
+    private Boolean tokenManagerUsesParser;
 
     /**
      * The name of the base class for the generated <code>Token</code> class. Default value is
@@ -240,32 +240,32 @@ public abstract class AbstractJavaCCMojo
      * is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.sanityCheck", defaultValue = "true")
-    private boolean sanityCheck;
+    @Parameter(property = "javacc.sanityCheck")
+    private Boolean sanityCheck;
 
     /**
      * This option setting controls lookahead ambiguity checking performed by JavaCC. Default value is
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.forceLaCheck", defaultValue = "false")
-    private boolean forceLaCheck;
+    @Parameter(property = "javacc.forceLaCheck")
+    private Boolean forceLaCheck;
 
     /**
      * Setting this option to <code>true</code> causes the generated parser to lookahead for extra tokens ahead of
      * time. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.cacheTokens", defaultValue = "false")
-    private boolean cacheTokens;
+    @Parameter(property = "javacc.cacheTokens")
+    private Boolean cacheTokens;
 
     /**
      * A flag whether to keep line and column information along with a token. Default value is <code>true</code>.
      * 
      * @parameter property="keepLineColumn"
      */
-    @Parameter(property = "javacc.keepLineColumn", defaultValue = "true")
-    private boolean keepLineColumn;
+    @Parameter(property = "javacc.keepLineColumn")
+    private Boolean keepLineColumn;
 
     /**
      * A flag whether the generated support classes of the parser should have public or package-private visibility.
@@ -273,7 +273,7 @@ public abstract class AbstractJavaCCMojo
      *
      * @since 2.6
      */
-    @Parameter(property = "javacc.supportClassVisibilityPublic", defaultValue = "true")
+    @Parameter(property = "javacc.supportClassVisibilityPublic")
     private Boolean supportClassVisibilityPublic;
 
     /**
@@ -352,7 +352,7 @@ public abstract class AbstractJavaCCMojo
      * Gets the granularity in milliseconds of the last modification date for testing whether a source needs
      * recompilation.
      * 
-     * @return The granularity in milliseconds of the last modification date for testing whether a source needs
+     * @return The granularity in milliseconds of the last modification date for testiintng whether a source needs
      *         recompilation.
      */
     protected abstract int getStaleMillis();

--- a/src/main/java/org/codehaus/mojo/javacc/JJDocMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJDocMojo.java
@@ -146,8 +146,8 @@ public class JJDocMojo
      * unless the parameter {@link #bnf} has been set to <code>true</code>. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.text", defaultValue = "false")
-    private boolean text;
+    @Parameter(property = "javacc.text")
+    private Boolean text;
 
     /**
      * A flag whether to generate a plain text document with the unformatted BNF. Note that setting this option to
@@ -156,7 +156,7 @@ public class JJDocMojo
      *
      * @since 2.6
      */
-    @Parameter(property = "javacc.bnf", defaultValue = "false")
+    @Parameter(property = "javacc.bnf")
     private Boolean bnf;
 
     /**

--- a/src/main/java/org/codehaus/mojo/javacc/JJTreeJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJTreeJavaCCMojo.java
@@ -45,24 +45,24 @@ public class JJTreeJavaCCMojo
      * grammar. Default value is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.buildNodeFiles", defaultValue = "true")
-    private boolean buildNodeFiles;
+    @Parameter(property = "javacc.buildNodeFiles")
+    private Boolean buildNodeFiles;
 
     /**
      * A flag whether to generate a multi mode parse tree or a single mode parse tree. Default value is
      * <code>false</code>.
      * 
      */
-    @Parameter(property = "javacc.multi", defaultValue = "false")
-    private boolean multi;
+    @Parameter(property = "javacc.multi")
+    private Boolean multi;
 
     /**
      * A flag whether to make each non-decorated production void instead of an indefinite node. Default value is
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeDefaultVoid", defaultValue = "false")
-    private boolean nodeDefaultVoid;
+    @Parameter(property = "javacc.nodeDefaultVoid")
+    private Boolean nodeDefaultVoid;
 
     /**
      * The name of a custom class that extends <code>SimpleNode</code> and will be used as the super class for the
@@ -98,7 +98,7 @@ public class JJTreeJavaCCMojo
      * <code>AST</code>.
      *
      */
-    @Parameter(property = "javacc.nodePrefix", defaultValue = "AST")
+    @Parameter(property = "javacc.nodePrefix")
     private String nodePrefix;
 
     /**
@@ -106,16 +106,16 @@ public class JJTreeJavaCCMojo
      * is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeScopeHook", defaultValue = "false")
-    private boolean nodeScopeHook;
+    @Parameter(property = "javacc.nodeScopeHook")
+    private Boolean nodeScopeHook;
 
     /**
      * A flag whether the node construction routines need an additional method parameter to receive the parser object.
      * Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeUsesParser", defaultValue = "false")
-    private boolean nodeUsesParser;
+    @Parameter(property = "javacc.nodeUsesParser")
+    private Boolean nodeUsesParser;
 
     /**
      * A flag whether to insert the methods <code>jjtGetFirstToken()</code>, <code>jjtSetFirstToken()</code>,
@@ -124,16 +124,16 @@ public class JJTreeJavaCCMojo
      * 
      * @since 2.5
      */
-    @Parameter(property = "javacc.trackTokens", defaultValue = "false")
-    private boolean trackTokens;
+    @Parameter(property = "javacc.trackTokens")
+    private Boolean trackTokens;
 
     /**
      * A flag whether to insert a <code>jjtAccept()</code> method in the node classes and to generate a visitor
      * implementation with an entry for every node type used in the grammar. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.visitor", defaultValue = "false")
-    private boolean visitor;
+    @Parameter(property = "javacc.visitor")
+    private Boolean visitor;
 
     /**
      * The name of a class to use for the data argument of the <code>jjtAccept()</code> and <code>visit()</code>

--- a/src/main/java/org/codehaus/mojo/javacc/JJTreeMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJTreeMojo.java
@@ -46,7 +46,7 @@ public class JJTreeMojo
      *
      * @since 2.4
      */
-    @Parameter(property = "javacc.jdkVersion", defaultValue = "1.4")
+    @Parameter(property = "javacc.jdkVersion")
     private String jdkVersion;
 
     /**
@@ -54,24 +54,24 @@ public class JJTreeMojo
      * grammar. Default value is <code>true</code>.
      * 
      */
-    @Parameter(property = "javacc.buildNodeFiles", defaultValue = "true")
-    private boolean buildNodeFiles;
+    @Parameter(property = "javacc.buildNodeFiles")
+    private Boolean buildNodeFiles;
 
     /**
      * A flag whether to generate a multi mode parse tree or a single mode parse tree. Default value is
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.multi", defaultValue = "false")
-    private boolean multi;
+    @Parameter(property = "javacc.multi")
+    private Boolean multi;
 
     /**
      * A flag whether to make each non-decorated production void instead of an indefinite node. Default value is
      * <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeDefaultVoid", defaultValue = "false")
-    private boolean nodeDefaultVoid;
+    @Parameter(property = "javacc.nodeDefaultVoid")
+    private Boolean nodeDefaultVoid;
 
     /**
      * The name of a custom class that extends <code>SimpleNode</code> and will be used as the super class for the
@@ -115,24 +115,24 @@ public class JJTreeMojo
      * is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeScopeHook", defaultValue = "false")
-    private boolean nodeScopeHook;
+    @Parameter(property = "javacc.nodeScopeHook")
+    private Boolean nodeScopeHook;
 
     /**
      * A flag whether the node construction routines need an additional method parameter to receive the parser object.
      * Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.nodeUsesParser", defaultValue = "false")
-    private boolean nodeUsesParser;
+    @Parameter(property = "javacc.nodeUsesParser")
+    private Boolean nodeUsesParser;
 
     /**
      * A flag whether to generate code for a static parser. Note that this setting must match the corresponding option
      * for the <code>javacc</code> mojo. Default value is <code>true</code>.
      *
      */
-    @Parameter(property = "javacc.isStatic", defaultValue = "true", alias = "javacc.staticOption")
-    private boolean isStatic;
+    @Parameter(property = "javacc.isStatic", alias = "javacc.staticOption")
+    private Boolean isStatic;
 
     /**
      * A flag whether to insert the methods <code>jjtGetFirstToken()</code>, <code>jjtSetFirstToken()</code>,
@@ -141,16 +141,16 @@ public class JJTreeMojo
      *
      * @since 2.5
      */
-    @Parameter(property = "javacc.trackTokens", defaultValue = "false")
-    private boolean trackTokens;
+    @Parameter(property = "javacc.trackTokens")
+    private Boolean trackTokens;
 
     /**
      * A flag whether to insert a <code>jjtAccept()</code> method in the node classes and to generate a visitor
      * implementation with an entry for every node type used in the grammar. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.visitor", defaultValue = "false")
-    private boolean visitor;
+    @Parameter(property = "javacc.visitor")
+    private Boolean visitor;
 
     /**
      * The name of a class to use for the data argument of the <code>jjtAccept()</code> and <code>visit()</code>

--- a/src/main/java/org/codehaus/mojo/javacc/JTBJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JTBJavaCCMojo.java
@@ -74,24 +74,24 @@ public class JTBJavaCCMojo
      * If <code>true</code>, JTB will suppress its semantic error checking. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.supressErrorChecking", defaultValue = "false")
-    private boolean supressErrorChecking;
+    @Parameter(property = "javacc.supressErrorChecking")
+    private Boolean supressErrorChecking;
 
     /**
      * If <code>true</code>, all generated comments will be wrapped in <code>&lt;pre&gt;</code> tags so that they
      * are formatted correctly in API docs. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.javadocFriendlyComments", defaultValue = "false")
-    private boolean javadocFriendlyComments;
+    @Parameter(property = "javacc.javadocFriendlyComments")
+    private Boolean javadocFriendlyComments;
 
     /**
      * Setting this option to <code>true</code> causes JTB to generate field names that reflect the structure of the
      * tree instead of generic names like <code>f0</code>, <code>f1</code> etc. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.descriptiveFieldNames", defaultValue = "false")
-    private boolean descriptiveFieldNames;
+    @Parameter(property = "javacc.descriptiveFieldNames")
+    private Boolean descriptiveFieldNames;
 
     /**
      * The qualified name of a user-defined class from which all AST nodes will inherit. By default, AST nodes will
@@ -106,14 +106,14 @@ public class JTBJavaCCMojo
      *
      */
     @Parameter(property = "javacc.parentPointers")
-    private boolean parentPointers;
+    private Boolean parentPointers;
 
     /**
      * If <code>true</code>, JTB will include JavaCC "special tokens" in the AST. Default value is <code>false</code>.
      *
      */
     @Parameter(property = "javacc.specialTokens")
-    private boolean specialTokens;
+    private Boolean specialTokens;
 
     /**
      * If <code>true</code>, JTB will generate the following files to support the Schema programming language:
@@ -124,15 +124,15 @@ public class JTBJavaCCMojo
      * Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.scheme", defaultValue = "false")
-    private boolean scheme;
+    @Parameter(property = "javacc.scheme")
+    private Boolean scheme;
 
     /**
      * If <code>true</code>, JTB will generate a syntax tree dumping visitor. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.printer", defaultValue = "false")
-    private boolean printer;
+    @Parameter(property = "javacc.printer")
+    private Boolean printer;
 
     /**
      * The directory where the JavaCC grammar files (<code>*.jtb</code>) are located. It will be recursively scanned

--- a/src/main/java/org/codehaus/mojo/javacc/JTBMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JTBMojo.java
@@ -75,15 +75,15 @@ public class JTBMojo
      * If <code>true</code>, JTB will suppress its semantic error checking. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.supressErrorChecking", defaultValue = "false")
-    private boolean supressErrorChecking;
+    @Parameter(property = "javacc.supressErrorChecking")
+    private Boolean supressErrorChecking;
 
     /**
      * If <code>true</code>, all generated comments will be wrapped in <code>&lt;pre&gt;</code> tags so that they
      * are formatted correctly in API docs. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.javadocFriendlyComments", defaultValue = "false")
+    @Parameter(property = "javacc.javadocFriendlyComments")
     private Boolean javadocFriendlyComments;
 
     /**
@@ -91,7 +91,7 @@ public class JTBMojo
      * tree instead of generic names like <code>f0</code>, <code>f1</code> etc. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.descriptiveFieldNames", defaultValue = "false")
+    @Parameter(property = "javacc.descriptiveFieldNames")
     private Boolean descriptiveFieldNames;
 
     /**
@@ -106,15 +106,15 @@ public class JTBMojo
      * If <code>true</code>, all nodes will contain fields for its parent node. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.parentPointers", defaultValue = "false")
-    private boolean parentPointers;
+    @Parameter(property = "javacc.parentPointers")
+    private Boolean parentPointers;
 
     /**
      * If <code>true</code>, JTB will include JavaCC "special tokens" in the AST. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.specialTokens", defaultValue = "false")
-    private boolean specialTokens;
+    @Parameter(property = "javacc.specialTokens")
+    private Boolean specialTokens;
 
     /**
      * If <code>true</code>, JTB will generate the following files to support the Schema programming language:
@@ -125,14 +125,14 @@ public class JTBMojo
      * Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.scheme", defaultValue = "false")
-    private boolean scheme;
+    @Parameter(property = "javacc.scheme")
+    private Boolean scheme;
 
     /**
      * If <code>true</code>, JTB will generate a syntax tree dumping visitor. Default value is <code>false</code>.
      *
      */
-    @Parameter(property = "javacc.printer", defaultValue = "false")
+    @Parameter(property = "javacc.printer")
     private Boolean printer;
 
     /**


### PR DESCRIPTION
The changes in commit 0060422dfd8cc5a09657f5664c911b3f73d38b23 made
javacc-maven-plugin always explicitly override all javacc options with
their default (or user-specified) values. This conflicts with the use of
per-file options, since javacc will then ignore the options specified in
the grammar file, with a warning message similar to:

Warning: Line 4, Column 5: Command line setting of "ignore_case" modifies option value in file.

Restore the former behavior of letting javacc decide when an option is
not specified in pom.xml.

Fixes:  #25