### PR TITLE
Mark plugins as threadsafe.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 *.iml
 .idea
+.classpath
+.project
+.settings/

--- a/src/main/java/org/codehaus/mojo/javacc/JJDocMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJDocMojo.java
@@ -46,7 +46,7 @@ import org.apache.maven.reporting.MavenReportException;
  * @author <a href="mailto:pgier@redhat.com">Paul Gier</a>
  * @see <a href="https://javacc.dev.java.net/doc/JJDoc.html">JJDoc Documentation</a>
  */
-@Mojo(name = "jjdoc")
+@Mojo(name = "jjdoc", threadSafe = true)
 @Execute(phase = LifecyclePhase.GENERATE_SOURCES)
 public class JJDocMojo extends AbstractMavenReport {
 

--- a/src/main/java/org/codehaus/mojo/javacc/JJTreeJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJTreeJavaCCMojo.java
@@ -35,7 +35,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author Benjamin Bentmann
  *
  */
-@Mojo(name = "jjtree-javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "jjtree-javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class JJTreeJavaCCMojo extends AbstractJavaCCMojo {
 
     /**

--- a/src/main/java/org/codehaus/mojo/javacc/JJTreeMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JJTreeMojo.java
@@ -36,7 +36,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @deprecated As of version 2.4, use the <code>jjtree-javacc</code> goal instead.
  * @author jesse jesse.mcconnell@gmail.com
  */
-@Mojo(name = "jjtree", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "jjtree", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class JJTreeMojo extends AbstractPreprocessorMojo {
 
     /**

--- a/src/main/java/org/codehaus/mojo/javacc/JTBJavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JTBJavaCCMojo.java
@@ -36,7 +36,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @since 2.4
  * @author Benjamin Bentmann
  */
-@Mojo(name = "jtb-javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "jtb-javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class JTBJavaCCMojo extends AbstractJavaCCMojo {
 
     /**

--- a/src/main/java/org/codehaus/mojo/javacc/JTBMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JTBMojo.java
@@ -37,7 +37,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author Gregory Kick (gk5885@kickstyle.net)
  *
  */
-@Mojo(name = "jtb", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "jtb", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class JTBMojo extends AbstractPreprocessorMojo {
 
     /**

--- a/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
+++ b/src/main/java/org/codehaus/mojo/javacc/JavaCCMojo.java
@@ -36,7 +36,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author jesse jesse.mcconnell@gmail.com
  *
  */
-@Mojo(name = "javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "javacc", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class JavaCCMojo extends AbstractJavaCCMojo {
 
     /**


### PR DESCRIPTION
As far as I can tell, the JavaCC Mojo's are carefully designed to be thread safe: The only instance variables are the parameters, which can be considered read-only.

As a consequence, I think that we can, and should, mark them as threadsafe. Which is, what this pull request does.
